### PR TITLE
Convert to a nightly build schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Builds
 on:
   workflow_dispatch:
   schedule:
-    - cron: "37 * * * *"
+    - cron: "37 22 * * *"
 
 jobs:
   periodic_release:


### PR DESCRIPTION
Update the hourly build to be nightly after testing shows that the
syntax is now working. Suggestion is to schedule off 'peak times' to
avoid overloading the GH scheduling system (it will automatically
reschedule your build should it show up during a flurry of build
requests) so I've set the deployment to go at 22:37 UTC time.
