### PR TITLE
Use the 'master' inspection tag vs 'latest'

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,6 +58,7 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
           QUAY_INFRAWATCH_OPERATORS_USERNAME: ${{ secrets.QUAY_INFRAWATCH_OPERATORS_USERNAME }}
           QUAY_INFRAWATCH_OPERATORS_PASSWORD: ${{ secrets.QUAY_INFRAWATCH_OPERATORS_PASSWORD }}
+          IMAGE_TAG: "master"
 
   periodic_release_1_5:
     name: Periodic Release for STF 1.5

--- a/releaser.sh
+++ b/releaser.sh
@@ -4,7 +4,7 @@ set +x
 # WARNING: this script is used by the GitHub Actions automation and isn't necessarily designed to be consumed directly.
 
 # set defaults that can be overridden
-INSPECTION_TAG=${INSPECTION_TAG:-latest}
+INSPECTION_TAG=${INSPECTION_TAG:-master}
 BUNDLE_TAG=${BUNDLE_TAG:-nightly-head}
 SGO_BUNDLE_RESULT_DIR=${SGO_BUNDLE_RESULT_DIR:-${GITHUB_WORKSPACE}/sgo-bundle}
 STO_BUNDLE_RESULT_DIR=${STO_BUNDLE_RESULT_DIR:-${GITHUB_WORKSPACE}/sto-bundle}


### PR DESCRIPTION
The 'latest' tag is no longer being used in the quay registry, so update the script to default to 'master' instead.
