### PR TITLE
Bump checkout GHA to v3 from v2

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get install -y shellcheck
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run shellcheck
         run: shellcheck *.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,19 +36,19 @@ jobs:
         run: sudo mv opm /usr/local/bin
 
       - name: Get Smart Gateway Operator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: infrawatch/smart-gateway-operator
           path: smart-gateway-operator
 
       - name: Get Service Telemetry Operator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: infrawatch/service-telemetry-operator
           path: service-telemetry-operator
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: release-automation
 
@@ -90,21 +90,21 @@ jobs:
         run: sudo mv opm /usr/local/bin
 
       - name: Get Smart Gateway Operator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: infrawatch/smart-gateway-operator
           path: smart-gateway-operator
           ref: stable-1.5
 
       - name: Get Service Telemetry Operator
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: infrawatch/service-telemetry-operator
           path: service-telemetry-operator
           ref: stable-1.5
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: release-automation
 


### PR DESCRIPTION
The checkout GitHub Action was using v2 which is deprecated due to use
of Node.js 12 in favour of Node.js 16. The checkout v2 usage in our
workflow definitions isn't using any parameters that aren't compatible
with v3, so no changes other than the version bump is expected to be
needed here.
