### PR TITLE
Update GH actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   shellcheck:
     name: Shellcheck scripts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install shellcheck

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   periodic_release_head:
     name: Periodic Release for HEAD
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Get operator-sdk
@@ -67,7 +67,7 @@ jobs:
 
   periodic_release_1_5:
     name: Periodic Release for STF 1.5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Get operator-sdk


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.

Actions need to be updated to a newer version.

For some jobs we are already using ubuntu-latest, so use the same for the jobs using ubuntu20.04