### PR TITLE
Use operator-sdk v1.39.2

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
 
       - name: Get operator-sdk
-        run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk-$RELEASE_VERSION-x86_64-linux-gnu
+        run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
         env:
-          RELEASE_VERSION: v0.19.4
+          RELEASE_VERSION: v1.39.2
 
       - name: Get opm
         run: curl --output opm -JL https://github.com/operator-framework/operator-registry/releases/download/$RELEASE_VERSION/linux-amd64-opm
@@ -71,9 +71,9 @@ jobs:
 
     steps:
       - name: Get operator-sdk
-        run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk-$RELEASE_VERSION-x86_64-linux-gnu
+        run: curl --output operator-sdk -JL https://github.com/operator-framework/operator-sdk/releases/download/$RELEASE_VERSION/operator-sdk_linux_amd64
         env:
-          RELEASE_VERSION: v0.19.4
+          RELEASE_VERSION: v1.39.2
 
       - name: Get opm
         run: curl --output opm -JL https://github.com/operator-framework/operator-registry/releases/download/$RELEASE_VERSION/linux-amd64-opm


### PR DESCRIPTION
Update actions to get operator-sdk v1.39.2

This change is required to align with STO/SGO
- https://github.com/infrawatch/service-telemetry-operator/pull/666
- https://github.com/infrawatch/smart-gateway-operator/pull/170